### PR TITLE
Updates to pages.

### DIFF
--- a/packages/pages/pages.js
+++ b/packages/pages/pages.js
@@ -158,12 +158,14 @@ Meteor.startup(function(){
     this.wait(subs);
     if (subs.ready()) {
       var page = orion.pages.collection.findOne({ url: this.params.url });
-      var template = orion.pages.templates[page.template];
       if (page) {
+        var template = orion.pages.templates[page.template];
         if (template.layout) {
           this.layout(template.layout);
         }
         this.render(page.template, {data: page});
+      } else {
+        this.render('notFound');
       }
     }
   }, { name: 'pages' });


### PR DESCRIPTION
This update fixes the following 

- Moves var template inside of the check for `if(page)` at line 161. The reason for this is because the template is not checked upon a conditional, and therefore when a user types in a url that no longer exist, or does not exist, they get a white screen. 

- By defining  an else statement at line 167 this .render('notFound') is dispatched if the page was not successfully found and possessed. The user can then define a `notFound` template in their code, and this template will be used instead of rendering a white screen.