### PR TITLE
Fixed security issue with non public config keys

### DIFF
--- a/packages/config/config.js
+++ b/packages/config/config.js
@@ -114,3 +114,11 @@ orion.config.getPublicFields = function() {
   var atts = this.collection.simpleSchema() && _.where(this.collection.simpleSchema()._schema, { public: true });
   return atts && _.pluck(atts, 'name');
 };
+
+/**
+ * Returns fields that are not public
+ */
+orion.config.getPrivateFields = function() {
+  var atts = this.collection.simpleSchema() && _.where(this.collection.simpleSchema()._schema, { public: false });
+  return atts && _.pluck(atts, 'name');
+};

--- a/packages/config/config_server.js
+++ b/packages/config/config_server.js
@@ -46,10 +46,19 @@ Meteor.startup(function () {
     Inject.obj('orion.config', {});
     return;
   }
-  var fields = { _id: 0 };
+
+   var fields = { _id: 0 };
   _.each(orion.config.getPublicFields(), function(field) {
     fields[field] = 1;
   });
+
+  //we needs to add in private fields so we can tell our query to not return them
+  //so that private fields won't be injected and remain secure
+  _.each(orion.config.getPrivateFields(), function(field) {
+    fields[field] = 0;
+  });
+
   var config = orion.config.collection.findOne({}, { fields: fields });
+  
   Inject.obj('orion.config', config);
 });


### PR DESCRIPTION
Currently, orion config keys with {public: false} are still injected into the head of the client html. This is a serious security issue when exposing secret keys, especially if you are dealing with payments.

Even though public fields were being checked for before injection, even fields that shouldn't be included must specifically be declared to not be returned when using the fields operator. Now I grab the private fields and add them to the query to make sure they are not injected.