### PR TITLE
Remove private fields from config in memory, instead of using fields query.

### DIFF
--- a/packages/config/config_server.js
+++ b/packages/config/config_server.js
@@ -47,15 +47,17 @@ Meteor.startup(function () {
     return;
   }
 
-   var fields = { _id: 0 };
+  //query config object, then remove
+  //the _id field and any other fields that are not
+  //set to {public: true}
+  var config = orion.config.collection.findOne({});
+  delete config._id;
 
-  //we needs to add in private fields so we can tell our query to not return them
-  //so that private fields won't be injected and remain secure
-  _.each(orion.config.getPrivateFields(), function(field) {
-    fields[field] = 0;
-  });
+  var privateFields = orion.config.getPrivateFields();
 
-  var config = orion.config.collection.findOne({}, { fields: fields });
-  
+  for (var i = 0; i < privateFields.length; i++) {
+    delete config[privateFields[i]];
+  }
+
   Inject.obj('orion.config', config);
 });


### PR DESCRIPTION
Previously, I was using getPrivateFields() to mix and match inclusion and exclusion fields on the field query object. Apparently this is not possible, and if you try to mix public and private settings keys, mongo will throw and error.

Since it appears to be difficult to query to the object the way we want to, I instead query all of the fields, and then remove the ones that are not public in memory.