### PR TITLE
add ability to configureRoute on /login

### DIFF
--- a/packages/accounts/authentication/login.js
+++ b/packages/accounts/authentication/login.js
@@ -3,10 +3,12 @@
  */
 ReactiveTemplates.request('login');
 
-/**
- * Register the routes
- */
-Router.route('/login', function () {
-  this.layout(ReactiveTemplates.get('outAdminLayout'));
-  this.render(ReactiveTemplates.get('login'));
-}, { name: 'login' });
+Tracker.autorun(function () {
+  if (ReactiveTemplates.get('login') && ReactiveTemplates.get('outAdminLayout'))
+  AccountsTemplates.configureRoute('signIn', {
+    name: 'login',
+    path: '/login',
+    template: ReactiveTemplates.get('login'),
+    layoutTemplate: ReactiveTemplates.get('outAdminLayout')
+  });
+});


### PR DESCRIPTION
In Useraccounts, there is a function called [configureRoute](https://github.com/meteor-useraccounts/core/blob/master/Guide.md#routing).

For example:

```
AccountsTemplates.configureRoute('signIn', {
    name: 'signin',
    path: '/login',
    template: 'myLogin',
    layoutTemplate: 'myLayout',
    redirect: '/user-profile',
});
```

So I have no problem using configureRoute with route codes such as signUp and forgotPwd.

There is only with signIn that I am not able to use configureRoute.

If I write 
```
AccountsTemplates.configureRoute('signIn', {
  name: 'signIn',
  path: '/login',
  template: 'login',
  layoutTemplate: 'homepage'
});
```

I get:
```
Error: A route for the path "/login" already exists by the name of "signIn".
    at Iron.utils.assert (packages/iron:core/lib/iron_core.js:10:1)
    at Function.Router.route (packages/iron:router/lib/router.js:137:1)
    at packages/useraccounts:core/lib/core.js:636:1
    at Function._.each._.forEach (packages/underscore/underscore.js:113:1)
    at [object Object].AT.setupRoutes (packages/useraccounts:core/lib/core.js:572:1)
    at [object Object].AT._init (packages/useraccounts:core/lib/server.js:142:1)
    at Meteor.methods.ATRemoveService.userId (packages/useraccounts:core/lib/server.js:170:1)
    at /Users/frabrunelle/satoshiportal/.meteor/local/build/programs/server/boot.js:229:5
```
And if I write
```
AccountsTemplates.configureRoute('signIn', {
  name: 'login',
  path: '/login',
  template: 'login',
  layoutTemplate: 'homepage'
});
```

I get 
```
Error: Handler with name 'login' already exists.
    at [object Object].MiddlewareStack._create (packages/iron:middleware-stack/lib/middleware_stack.js:31:1)
    at [object Object].MiddlewareStack.push (packages/iron:middleware-stack/lib/middleware_stack.js:47:1)
    at Function.Router.route (packages/iron:router/lib/router.js:131:1)
    at packages/useraccounts:core/lib/core.js:636:1
    at Function._.each._.forEach (packages/underscore/underscore.js:113:1)
    at [object Object].AT.setupRoutes (packages/useraccounts:core/lib/core.js:572:1)
    at [object Object].AT._init (packages/useraccounts:core/lib/server.js:142:1)
    at Meteor.methods.ATRemoveService.userId (packages/useraccounts:core/lib/server.js:170:1)
    at /Users/frabrunelle/satoshiportal/.meteor/local/build/programs/server/boot.js:229:5
```

As far as I know, this is caused by [the following code](https://github.com/orionjs/orion/blob/d8e232b60d84ce5ca460d010d93584f8bcce1cb6/packages/accounts/authentication/login.js#L9):

```
Router.route('/login', function () {
  this.layout(ReactiveTemplates.get('outAdminLayout'));
  this.render(ReactiveTemplates.get('login'));
}, { name: 'login' });
```
It would be nice to fix this. Otherwise it's not really possible to specify a signInLink. Which is useful in my case because I am using the configureRoute function to specify a /register page and when people go to that page, they see "If you already have an account sign in" under the registration form and so I want the sign in link to point to /login instead of /register#. This is only possible by using the configureRoute function.

For example, I would write:

```
AccountsTemplates.configureRoute('signIn', {
  name: 'login',
  path: '/login',
  template: ReactiveTemplates.get('login'),
  layoutTemplate: ReactiveTemplates.get('outAdminLayout')
});
```

So the fix I found was to replace the code that was causing the error with:

```
Tracker.autorun(function () {
  if (ReactiveTemplates.get('login') && ReactiveTemplates.get('outAdminLayout'))
  AccountsTemplates.configureRoute('signIn', {
    name: 'login',
    path: '/login',
    template: ReactiveTemplates.get('login'),
    layoutTemplate: ReactiveTemplates.get('outAdminLayout')
  });
});
```

The reason I put the code inside Tracker.autorun and checked if the value of the reactive templates were set is that the reactive templates are set in another file and so the code will crash if I don't do that. Maybe there is a better way to write it, I don't know.

The other solution I thought was to make a pull request to [useraccounts/core](https://github.com/meteor-useraccounts/core) that lets the template and layoutTemplate parameters (of configureRoute) be a function (right now it can only be a string).

But I thought I would make a pull request here first since I got this problem while using Orion and I would like to know what you guys think!

TLDR: Right now most Orion applications have the sign in and sign up template on the same page (/login) but I think there should also be the ability to have them on separate pages (e.g., /login and /register). This is sort of possible right now, but the problem is that the [signInLink helper](https://github.com/meteor-useraccounts/core/blob/f3d724955613187f0f326dbb49e45a1e3186364f/lib/templates_helpers/at_signin_link.js) (from the [atSigninLink template](https://github.com/meteor-useraccounts/bootstrap/blob/d119106503bd029d60902bf7c28af8fcd7db2cc6/lib/at_signin_link.html)) will display an empty path (/register# instead of /login). To fix this, we need to use configureRoute, but this is not possible right now for the signIn route code.
