### PR TITLE
Move myAccount to dropdown

### DIFF
--- a/packages/accounts/my-account/admin.js
+++ b/packages/accounts/my-account/admin.js
@@ -51,7 +51,19 @@ if (Meteor.isClient) {
       section: 'user',
       title: i18n('accounts.myAccount.title'),
       routeName: 'myAccount.index',
-      activeRouteRegex: 'myAccount',
+      activeRouteRegex: 'myAccount'
+    });
+    orion.addLink({
+      section: 'user',
+      title: i18n('accounts.updateProfile.title'),
+      routeName: 'myAccount.profile',
+      activeRouteRegex: 'myAccount.profile'
+    });
+    orion.addLink({
+      section: 'user',
+      title: i18n('accounts.changePassword.title'),
+      routeName: 'myAccount.password',
+      activeRouteRegex: 'myAccount.password'
     });
   });
 

--- a/packages/accounts/my-account/admin.js
+++ b/packages/accounts/my-account/admin.js
@@ -51,7 +51,7 @@ if (Meteor.isClient) {
       section: 'user',
       title: i18n('accounts.myAccount.title'),
       routeName: 'myAccount.index',
-      activeRouteRegex: 'myAccount'
+      activeRouteRegex: 'myAccount.index'
     });
     orion.addLink({
       section: 'user',

--- a/packages/bootstrap/views/layout/layout.html
+++ b/packages/bootstrap/views/layout/layout.html
@@ -21,9 +21,9 @@
     </div>
   </div>
   <style type="text/css">
-  html, body {
-    overflow: visible;
-  }
+    html, body {
+      overflow: visible;
+    }
   </style>
 </template>
 
@@ -45,10 +45,28 @@
         <a class="menu-toggle navbar-brand">
           <i class="fa fa-bars"></i>
         </a>
+        <a class="navbar-toggle collapsed" data-toggle="collapse" data-target="#user-profile-dropdown">
+          <i class="fa fa-user"></i>
+        </a>
       </div>
     </div>
-    <div class="navbar-collapse collapse navbar-responsive-collapse">
+    <div class="navbar-collapse collapse navbar-responsive-collapse navbar-inverse" id="user-profile-dropdown">
       <ul class="nav navbar-nav navbar-right">
+        <li class="dropdown">
+          <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true"
+             aria-expanded="false">
+            {{ currentUser.profile.name }} <span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu">
+            {{# each adminLinks 'user' }}
+              <li class="{{ isActiveRoute regex=activeRouteRegex }}">
+                <a href="{{ pathFor routeName }}" class="grey-text text-darken-4">{{ title }}</a>
+              </li>
+            {{/ each }}
+            <li role="separator" class="divider"></li>
+            <li><a href="#" class="logout"><i class="fa fa-sign-out"></i> {{ i18n 'global.logout' }}</a></li>
+          </ul>
+        </li>
       </ul>
     </div>
   </div>
@@ -61,6 +79,7 @@
     </div>
   </div>
 </template>
+
 <template name="orionBootstrapMediumContentOffset">
   <div class="row">
     <div class="col-sm-10 col-sm-offset-1">
@@ -68,6 +87,7 @@
     </div>
   </div>
 </template>
+
 <template name="orionBootstrapContentContainer">
   <div class="well">
     {{> yield }}
@@ -75,7 +95,7 @@
 </template>
 
 <template name="orionBootstrapTitle">
-  <h1 class="title">  
+  <h1 class="title">
     {{> yield }}
   </h1>
   <hr>

--- a/packages/bootstrap/views/layout/layout.js
+++ b/packages/bootstrap/views/layout/layout.js
@@ -9,6 +9,12 @@ Template.orionBootstrapLayout.events({
   }
 });
 
+Template.orionBootstrapHeader.events({
+  'click .logout': function() {
+    Meteor.logout();
+  }
+});
+
 Template.orionBootstrapTabs.helpers({
   items: function () {
     return this;

--- a/packages/bootstrap/views/layout/layout.less
+++ b/packages/bootstrap/views/layout/layout.less
@@ -129,6 +129,19 @@
     background: none;
   }
 
+  .dropdown-menu > .active > a,
+  .dropdown-menu > .active > a:hover,
+  .dropdown-menu > .active > a:focus {
+    color: #333;
+    background-color: #D5D9DD;
+  }
+
+  .navbar-header .navbar-toggle {
+    line-height: 20px;
+    font-size: 18px;
+    color: #ffffff;
+  }
+
   @media(max-width:767px) {
     html, body {
       .no-overflow {

--- a/packages/bootstrap/views/sidebar/sidebar.html
+++ b/packages/bootstrap/views/sidebar/sidebar.html
@@ -12,9 +12,6 @@
       {{# each adminLinks 'medium' }}
         {{> orionBootstrapSidebarLink }}
       {{/ each }}
-      {{# each adminLinks 'user' }}
-        {{> orionBootstrapSidebarLink }}
-      {{/ each }}
       {{# each adminLinks 'bottom' }}
         {{> orionBootstrapSidebarLink }}
       {{/ each }}


### PR DESCRIPTION
As discussed in the [forums](http://forums.orionjs.org/t/what-about-removing-my-account/65), I made
the following changes:

1. I created a right dropdown for the bootstrap theme with responsive support in by adding a
user icon in the top right corner when in mobile mode. (I also modified
the layout.less for this part).

2. I moved the each adminLinks ‘user’ helper cycle from the sidebar to
the dropdown. (As it already is in the materialize theme).

3. I added a logout event for the orionBootstrapHeader Template.

4. I added the myAccount.profile and myAccount.password links to the
‘user’ section in the accounts package.

The Materialize theme doesn’t require any editing because it was already
using a top right dropdown for profile links.