### PR TITLE
remove the login route, let the user configure it instead

### DIFF
--- a/packages/accounts/authentication/login.js
+++ b/packages/accounts/authentication/login.js
@@ -2,11 +2,3 @@
  * Init the template name variable
  */
 ReactiveTemplates.request('login');
-
-/**
- * Register the routes
- */
-Router.route('/login', function () {
-  this.layout(ReactiveTemplates.get('outAdminLayout'));
-  this.render(ReactiveTemplates.get('login'));
-}, { name: 'login' });


### PR DESCRIPTION
I wasn't able to see the warnings you refer to in #217.

> The code was creating warnings.
> You can't change configure the login route after the initialization of AccountsTemplates

And I am not sure what you mean by "you can't configure the login router after the initialization of AccountsTemplates". Don't you mean **before** the initialization of AccountsTemplates?

Or if that's you mean, can you please clarify? :smile: 

Anyways, I had another idea. We could also just remove the login route from Orion.

So specifically, that part:

```
/**
 * Register the routes
 */
Router.route('/login', function () {
  this.layout(ReactiveTemplates.get('outAdminLayout'));
  this.render(ReactiveTemplates.get('login'));
}, { name: 'login' });
```

That way, the `/admin` route would still work for people who install Orion. And they could use it to login and register.

But if they want a `/login` route (or `/signin`, etc.), then they could define that route in `lib/options.js`:

```
AccountsTemplates.configureRoute('signIn', {
  name: 'login',
  path: '/login',
  template: ReactiveTemplates.get('login'),
  layoutTemplate: ReactiveTemplates.get('outAdminLayout')
});
```

And same thing for a `/register` route (this currently works, only `/login` doesn't work):

```
AccountsTemplates.configureRoute('signUp', {
  name: 'register',
  path: '/register',
  template: ReactiveTemplates.get('login'),
  layoutTemplate: ReactiveTemplates.get('outAdminLayout')
});
```

As long as we give these examples in the documentation, I think it would be a great solution and provide more flexibility.

My other PR seemed to work fine as well (I'm don't know where I can see the warnings) but at this point I am pretty much convinced that removing that part of the code is the way to go.

Like I said, `/admin` will still work out of the box and people can refer to the documentation to configure their own `/login` route.