### PR TITLE
fix label formatting on image-attribute admin button using materialize

### DIFF
--- a/packages/image-attribute/image.html
+++ b/packages/image-attribute/image.html
@@ -18,14 +18,14 @@
             </div>
           {{/ if }}
         {{ else }}
-          <span class="btn btn-default btn-file btn-xs">
+            <br>
+          <span class="btn btn-default btn-file btn-xs input-field">
             {{ i18n 'attributes.image.choose' }} <input type="file">
           </span>
         {{/ if }}
       {{/ if }}
     </div>
   </div>
-  <br>
 </template>
 
 <template name="orionAttributesImageUploadColumn">


### PR DESCRIPTION
Currently, the button on the admin page for the image button using materialize has some broken formatting:
![image-before](https://cloud.githubusercontent.com/assets/2671007/8881662/30bfef42-3274-11e5-82ac-d91b2d51cf18.PNG)

Fixed by moving the `<br>` tag and adding the `input-field` class to the element containing the button, copying the formatting from the "orionMaterializeFileAttribute" template:
![image-after](https://cloud.githubusercontent.com/assets/2671007/8881716/6ade5894-3274-11e5-8256-5dfea475d8bd.PNG)

This doesn't address the other inconsistencies between the two buttons (size, presence of waves-effect on file and not image, etc); not sure if the differences are intentional/, due to file-attribute having a separate materialize version but image-attribute not, or something else.
