### PR TITLE
clicking on the main admin panel will not reopen the navbar

### DIFF
--- a/packages/bootstrap/views/layout/layout.js
+++ b/packages/bootstrap/views/layout/layout.js
@@ -1,5 +1,5 @@
 Template.orionBootstrapLayout.events({
-  'click .orion-bootstrap-admin.toggled': function() {
+  'resize .orion-bootstrap-admin.toggled': function() {
     if ($(window).width() < 768) {
       $(".orion-bootstrap-admin").removeClass("toggled");
       $("html,body").removeClass("no-overflow");


### PR DESCRIPTION
I think that this should be the solution to #249. This way clicking on the admin area will not toggle the navbar again, which is probably an unwanted behavior.

Cheers!