### PR TITLE
Made image deletion more obvious

### DIFF
--- a/packages/image-attribute/image.less
+++ b/packages/image-attribute/image.less
@@ -35,6 +35,35 @@
 
   .delete-btn {
     cursor: pointer;
+    display: inline-block;
+    position: relative;
+
+    &::before {
+      bottom: 0;
+      color: #f00;
+      content: "×";
+      font-size: 2em;
+      font-weight: bold;
+      left: 5px;
+      line-height: 0.7em;
+      position: absolute;
+      right: 5px;
+      text-shadow:
+        -1px -1px 0 #fff,
+        1px -1px 0 #fff,
+        -1px 1px 0 #fff,
+        1px 1px 0 #fff;
+      top: 5px;
+      transition: all 100ms ease-in-out;
+    }
+
+    &:hover {
+      &::before {
+        font-size: 5em;
+        text-align: center;
+        top: 0;
+      }
+    }
   }
 
   img {

--- a/packages/image-attribute/images.html
+++ b/packages/image-attribute/images.html
@@ -2,7 +2,9 @@
   <div class="images-attribute" {{ this.atts }}>
     <p>
       {{# each images }}
-        <img src="{{ url }}" class="delete-btn" />
+        <div class="delete-btn" title="Delete image">
+          <img src="{{ url }}" />
+        </div>
       {{/ each }}
       {{# each uploads }}
         <img class="base64-preview uploading" src="{{ base64 }}" />


### PR DESCRIPTION
It wasn't clear at all that clicking on an image would delete it (expected behavior would be to enlarge it). I've corrected this, though ideally clicking the image would enlarge it, and there would be a separate button to delete it.