### PR TITLE
Allow sortFields options to define sorting of selectable values

### DIFF
--- a/packages/relationships/attribute.js
+++ b/packages/relationships/attribute.js
@@ -10,6 +10,7 @@ var getSchema = function(options, hasMany) {
     createFilter: Match.Optional(Function),
     create: Match.Optional(Function),
     additionalFields: Match.Optional(Array),
+    sortFields: Match.Optional(Match.OneOf(Array, Object)),
     render: Match.Optional({
       item: Function,
       option: Function

--- a/packages/relationships/relationships.js
+++ b/packages/relationships/relationships.js
@@ -4,6 +4,16 @@ var initSelect = function(template, dataContext, schema, options) {
     labelField: options.titleField,
     items: _.isArray(dataContext.value) ? dataContext.value : [dataContext.value],
     searchField: schema.orion.fields,
+    sortField: _.union(
+      (
+        _.isArray(schema.orion.sortFields) ?
+          _.map(schema.orion.sortFields, function(sort_field) { return { field: sort_field, direction: 'asc' } })
+          :
+          _.map(schema.orion.sortFields, function(sort_order, sort_field) { return { field: sort_field, direction: sort_order } })
+      )
+      ,
+      [{field: '$score'}]
+    ),
     plugins: ['remove_button'],
     createFilter: schema.orion.createFilter,
     create: schema.orion.create,


### PR DESCRIPTION
Hi, as described on forum

http://forums.orionjs.org/t/solved-sort-of-relation-collection/116

this PR will allow to define sorting of relations.

As I checked on selectize, I made some changes to relationships.js and attributes.js to enable a new property called

sortFields

Usage

````
sortFields: [ 'your_field_name', 'second_field_name' ]
````

This will sort ascending

````
sortFields: { 'your_field_name': 'desc', 'second_field_name': 'asc' }
````

So you can choose for sort order

