### PR TITLE
Optional set an array of field names for titleField to display more values from related collection

### DIFF
--- a/packages/relationships/relationships.js
+++ b/packages/relationships/relationships.js
@@ -1,7 +1,7 @@
 var initSelect = function(template, dataContext, schema, options) {
   var element = template.$('select').selectize({
     valueField: '_id',
-    labelField: options.titleField,
+    labelField: _.isArray(options.titleField) ? options.titleField[0] : options.titleField,
     items: _.isArray(dataContext.value) ? dataContext.value : [dataContext.value],
     searchField: schema.orion.fields,
     plugins: ['remove_button'],


### PR DESCRIPTION
If you have define a relation, you normally can only show 1 field as Title for Selection and Display.

This PR allows to define also an array and so that concatinated fields are show.

`titleField: ['name', 'given_name', 'address', 'phone']`

Benefit is, that all is searchable via tabular too

Cheers
Tom
