### PR TITLE
assign account name upon creation

### DIFF
--- a/packages/accounts/create/server.js
+++ b/packages/accounts/create/server.js
@@ -15,10 +15,12 @@ Meteor.methods({
     if (options.password) {
       newUser.password = options.password;
     }
+    if (!!options.name) {
+      newUser.profile = { name: options.name };
+    }
 
     var userId = Accounts.createUser(newUser);
 
-    Meteor.users.update(userId, { $set: { profile: { name: options.name } } });
     Roles.setUserRoles(userId, options.roles);
 
     return userId;


### PR DESCRIPTION
Fixes a problem I have when using a collection2 schema where "profile.name" is required. This pull request will stop Simple Schema denying account creation when the required field "profile.name" is not present.