### PR TITLE
Fetch correct dictionary in case of process.env.ORION_APPID

### DIFF
--- a/packages/dictionary/dictionary.js
+++ b/packages/dictionary/dictionary.js
@@ -108,5 +108,5 @@ orion.dictionary.get = function(path, defaultValue) {
     }
   }
 
-  return orion.helpers.searchObjectWithDots(this.findOne(), path) || defaultValue;
+  return orion.helpers.searchObjectWithDots(this.findOne((process && process.env && process.env.ORION_APPID)?{_id:process.env.ORION_APPID}:{}), path) || defaultValue;
 };


### PR DESCRIPTION
A small oversight in my previous (honoured) pull-request. 
Also in case of server-side use of ```orion.dictionary.get()```, make sure the correct query parameters are provided to the ```findOne()``` call.

Regards,
Joris