### PR TITLE
Add 3rd Party Package to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,3 +115,4 @@ If you want to help translating Orion to your language follow the [instructions]
 **Others:**
 
 - [nicolaslopezj:orion-exporter](https://github.com/nicolaslopezj/orion-exporter) Export and import Orion data
+- [rwatts:orionjs-dashboard](https://atmospherejs.com/rwatts/orionjs-dashboard) Add a Dashboard & Widgets to Orion


### PR DESCRIPTION
Adds a link to `rwatts:orionjs-dashboard`