### PR TITLE
This packages `imply` way too much

### DIFF
--- a/packages/base/package.js
+++ b/packages/base/package.js
@@ -34,7 +34,6 @@ Package.onUse(function(api) {
     'underscore',
     'spacebars',
     'ecmascript',
-    'blaze-html-templates',
     'check',
     'tracker',
     'nicolaslopezj:router-layer',

--- a/packages/base/package.js
+++ b/packages/base/package.js
@@ -34,6 +34,7 @@ Package.onUse(function(api) {
     'underscore',
     'spacebars',
     'ecmascript',
+    'blaze-html-templates',
     'check',
     'tracker',
     'nicolaslopezj:router-layer',

--- a/packages/core/package.js
+++ b/packages/core/package.js
@@ -18,16 +18,6 @@ Package.onUse(function(api) {
     'orionjs:lang-en@1.7.0'
     ]);
 
-  api.imply([
-    'orionjs:lang-en',
-    'orionjs:base',
-    'orionjs:accounts',
-    'orionjs:config',
-    'orionjs:collections',
-    'orionjs:dictionary',
-    'orionjs:attributes',
-    ]);
-
   api.export('orion');
 });
 


### PR DESCRIPTION
I would like to complain a bit. The approach in this repository where so many packages are `imply`ed, makes it really hard to reuse this system with other Meteor packages:
* https://github.com/orionjs/orion/blob/master/packages/core/package.js#L21
* https://github.com/orionjs/orion/blob/master/packages/base/package.js#L30

It destroys the whole purpose of dependencies by creating one monolithic package you can or cannot use.

For example, it is now impossible to use `orionjs:core` together with [Blaze Components](https://github.com/peerlibrary/meteor-blaze-components) because `orionjs:core` implies `orionjs:base` which implies `blaze-html-templates`. Why it has to imply it and not just depend on it? This makes it problematic for users who would like to swap `templating` with Blaze Components and get also server side rendering.