### PR TITLE
Add material note

### DIFF
--- a/packages/materialnote/README.md
+++ b/packages/materialnote/README.md
@@ -1,0 +1,31 @@
+# MaterialNote for Orionjs
+
+This package is a bundling of the Materialnote from https://github.com/Cerealkillerway/materialNote
+
+
+It works just like summernote as an attribute.
+
+```
+Posts.attachSchema(new SimpleSchema({
+        title: {
+            type: String
+        },
+    
+        content: orion.attribute("materialnote",{
+            label: "Blog Post"
+        }),
+    
+        author: orion.attribute("createdBy"),
+        createdAt: orion.attribute("createdAt"),
+        updatedAt: orion.attribute("updatedAt"),
+        image: orion.attribute("image", {
+            label: "Top Image(Optional)",
+            optional: true
+        }),
+    }));
+    
+```
+
+BUGS
+
+Seems taht some of the summernote features like font changing

--- a/packages/materialnote/attribute.js
+++ b/packages/materialnote/attribute.js
@@ -1,0 +1,13 @@
+orion.attributes.registerAttribute('materialnote', {
+  template: 'orionAttributesMaterialnote',
+  previewTemplate: 'orionAttributesMaterialnoteColumn',
+  getSchema: function(options) {
+    return {
+      type: String
+    };
+  },
+  valueOut: function() {
+    return this.find('.materialnote').code();
+  }
+});
+

--- a/packages/materialnote/cktooltip.js
+++ b/packages/materialnote/cktooltip.js
@@ -1,0 +1,174 @@
+if (Meteor.isClient){
+    (function ($) {
+        $.fn.ckTooltip = function (options) {
+            var timeout = null,
+                counter = null,
+                started = false,
+                counterInterval = null,
+                margin = 5;
+
+            // Defaults
+            var defaults = {
+                delay: 350
+            };
+            options = $.extend(defaults, options);
+
+            return this.each(function(){
+                var origin = $(this);
+
+                // Create Text span
+                var tooltip_text = $('<span></span>').text(origin.attr('data-tooltip'));
+
+                // Create tooltip
+                var newTooltip = $('<div></div>');
+                newTooltip.addClass('material-tooltip').append(tooltip_text);
+                newTooltip.appendTo($('body'));
+
+                var backdrop = $('<div></div>').addClass('backdrop');
+                backdrop.appendTo(newTooltip);
+                backdrop.css({ top: 0, left:0 });
+
+                //Destroy previously binded events
+                //$(this).off('mouseenter mouseleave');
+
+                $.event.special.destroyed = {
+                    remove: function(o) {
+                        if (o.handler) {
+                            o.handler();
+                        }
+                    }
+                };
+                $(this).bind('destroyed', function() {
+                    newTooltip.remove();
+                });
+
+                // Mouse In
+                $(this).on({
+                    mouseenter: function(e) {
+                        var tooltip_delay = origin.data("delay");
+
+                        tooltip_delay = (tooltip_delay === undefined || tooltip_delay === '') ? options.delay : tooltip_delay;
+                        counter = 0;
+                        counterInterval = setInterval(function(){
+                            counter += 10;
+
+                            if (counter >= tooltip_delay && started === false) {
+                                started = true;
+                                newTooltip.css({ display: 'block', left: '0px', top: '0px' });
+
+                                // Set Tooltip text
+                                newTooltip.children('span').text(origin.attr('data-tooltip'));
+
+                                // Tooltip positioning
+                                var originWidth = origin.outerWidth();
+                                var originHeight = origin.outerHeight();
+                                var tooltipPosition =  origin.attr('data-position');
+                                var tooltipHeight = newTooltip.outerHeight();
+                                var tooltipWidth = newTooltip.outerWidth();
+                                var tooltipVerticalMovement = '0px';
+                                var tooltipHorizontalMovement = '0px';
+                                var scale_factor = 8;
+
+                                if (tooltipPosition === "top") {
+                                    // Top Position
+                                    newTooltip.css({
+                                        top: origin.offset().top - tooltipHeight - margin,
+                                        left: origin.offset().left + originWidth/2 - tooltipWidth/2
+                                    });
+                                    tooltipVerticalMovement = '-10px';
+                                    backdrop.css({
+                                        borderRadius: '14px 14px 0 0',
+                                        transformOrigin: '50% 90%',
+                                        marginTop: tooltipHeight,
+                                        marginLeft: (tooltipWidth/2) - (backdrop.width()/2)
+
+                                    });
+                                }
+                                // Left Position
+                                else if (tooltipPosition === "left") {
+                                    newTooltip.css({
+                                        top: origin.offset().top + originHeight/2 - tooltipHeight/2,
+                                        left: origin.offset().left - tooltipWidth - margin
+                                    });
+                                    tooltipHorizontalMovement = '-10px';
+                                    backdrop.css({
+                                        width: '14px',
+                                        height: '14px',
+                                        borderRadius: '14px 0 0 14px',
+                                        transformOrigin: '95% 50%',
+                                        marginTop: tooltipHeight/2,
+                                        marginLeft: tooltipWidth
+                                    });
+                                }
+                                // Right Position
+                                else if (tooltipPosition === "right") {
+                                    newTooltip.css({
+                                        top: origin.offset().top + originHeight/2 - tooltipHeight/2,
+                                        left: origin.offset().left + originWidth + margin
+                                    });
+                                    tooltipHorizontalMovement = '+10px';
+                                    backdrop.css({
+                                        width: '14px',
+                                        height: '14px',
+                                        borderRadius: '0 14px 14px 0',
+                                        transformOrigin: '5% 50%',
+                                        marginTop: tooltipHeight/2,
+                                        marginLeft: '0px'
+                                    });
+                                }
+                                else {
+                                    // Bottom Position
+                                    newTooltip.css({
+                                        top: origin.offset().top + origin.outerHeight() + margin,
+                                        left: origin.offset().left + originWidth/2 - tooltipWidth/2
+                                    });
+                                    tooltipVerticalMovement = '+10px';
+                                    backdrop.css({
+                                        marginLeft: (tooltipWidth/2) - (backdrop.width()/2)
+                                    });
+                                }
+
+                                // Calculate Scale to fill
+                                scale_factor = tooltipWidth / 8;
+                                if (scale_factor < 8) {
+                                    scale_factor = 8;
+                                }
+                                if (tooltipPosition === "right" || tooltipPosition === "left") {
+                                    scale_factor = tooltipWidth / 10;
+                                    if (scale_factor < 6)
+                                        scale_factor = 6;
+                                }
+
+                                newTooltip.velocity({ opacity: 1, marginTop: tooltipVerticalMovement, marginLeft: tooltipHorizontalMovement}, { duration: 150, queue: false });
+                                backdrop.css({ display: 'block' })
+                                    .velocity({opacity:1},{duration: 50, delay: 0, queue: false})
+                                    .velocity({scale: scale_factor}, {duration: 150, delay: 0, queue: false, easing: 'easeInOutQuad'});
+                            }
+                        }, 10); // End Interval
+
+                        // Mouse Out
+                    },
+                    mouseleave: function(){
+                        // Reset State
+                        clearInterval(counterInterval);
+                        counter = 0;
+
+                        // Animate back
+                        newTooltip.velocity({
+                            opacity: 0, marginTop: 0, marginLeft: 0}, { duration: 150, queue: false, delay: 50 }
+                        );
+                        backdrop.velocity({opacity: 0, scale: 1}, {
+                            duration:150,
+                            delay: 50, queue: false,
+                            complete: function(){
+                                backdrop.css('display', 'none');
+                                newTooltip.css('display', 'none');
+                                started = false;}
+                        });
+                    }
+                });
+            });
+        };
+
+    }(jQuery));
+}

--- a/packages/materialnote/materialnote.html
+++ b/packages/materialnote/materialnote.html
@@ -1,0 +1,13 @@
+<template name="orionAttributesMaterialnote">
+    <div class="orionMaterialnote" {{ atts }}>
+        {{# if isUploading }}
+            <br>
+            <div class="progress"><div class="progress-bar progress-bar-striped active" style="width: {{ progress }}%"></div></div>
+        {{/ if }}
+        <div class="materialnote"></div>
+    </div>
+</template>
+
+<template name="orionAttributesMaterialnoteColumn">
+    {{ preview }}
+</template>

--- a/packages/materialnote/materialnote.js
+++ b/packages/materialnote/materialnote.js
@@ -1,0 +1,63 @@
+// Write your package code here!
+ReactiveTemplates.onRendered('attribute.materialnote', function() {
+    this.subscribe('materialnoteImages');
+    Session.set('orionMaterialnoteIsUploading', false);
+    var element = this.$('.materialnote');
+    var toolbar = [
+        ['style', ['style', 'bold', 'italic', 'underline', 'strikethrough', 'clear']],
+        ['fonts', ['fontsize', 'fontname']],
+        ['color', ['color']],
+        ['undo', ['undo', 'redo', 'help']],
+        ['ckMedia', ['ckImageUploader', 'ckVideoEmbeeder']],
+        ['misc', ['link', 'picture', 'table', 'hr', 'codeview', 'fullscreen']],
+        ['para', ['ul', 'ol', 'paragraph', 'leftButton', 'centerButton', 'rightButton', 'justifyButton', 'outdentButton', 'indentButton']],
+        ['height', ['lineheight']],
+    ];
+    element.materialnote({
+        toolbar: toolbar,
+        height: 300,
+        onImageUpload: function(files, editor, $editable) {
+            var upload = orion.filesystem.upload({
+                fileList: files,
+                name: files[0].name,
+                uploader: 'materialnote'
+            });
+            Session.set('orionMaterialnoteIsUploading', true);
+            Session.set('orionMaterialnoteProgress', 0);
+            Tracker.autorun(function () {
+                if (upload.ready()) {
+                    if (upload.error) {
+                        console.log(upload.error);
+                        alert(upload.error.reason);
+                    } else {
+                        element.materialnote('insertImage', upload.url);
+                    }
+                    Session.set('orionMaterialnoteIsUploading', false);
+                }
+            });
+            Tracker.autorun(function () {
+                Session.set('orionMaterialnoteProgress', upload.progress());
+            });
+        }
+    });
+    element.code(this.data.value);
+})
+
+ReactiveTemplates.helpers('attribute.materialnote', {
+    isUploading: function() {
+        return Session.get('orionMaterialnoteIsUploading');
+    },
+    progress: function() {
+        return Session.get('orionMaterialnoteProgress');
+    }
+})
+
+ReactiveTemplates.helpers('attributePreview.materialnote', {
+    preview: function () {
+        var value = this.value;
+        var tmp = document.createElement("DIV");
+        var content = value.replace(/<(?:.|\n)*?>/gm, ' ');
+        if(content.length > 50) content = content.substring(0, 47).trim() + '...';
+        return content;
+    }
+});

--- a/packages/materialnote/materialnote.less
+++ b/packages/materialnote/materialnote.less
@@ -1,0 +1,10 @@
+.orionMaterialnote {
+  margin-top: 20px;
+  .note-editor {
+    background: #fff;
+
+    .note-toolbar {
+      background: #000;
+    }
+  }
+}

--- a/packages/materialnote/package.js
+++ b/packages/materialnote/package.js
@@ -16,14 +16,14 @@ Package.onUse(function (api) {
         'orionjs:base@1.7.0',
         'orionjs:attributes@1.7.0',
         'orionjs:filesystem@1.7.0',
-        'cerealkiller:materialnote@1.2.1',
+        'vojtechklos:materialnote@1.2.2',
         'less@2.5.0_2',
 
         'jquery'
     ]);
 
     api.imply([
-        'cerealkiller:materialnote',
+        'vojtechklos:materialnote',
     ]);
 
     api.addFiles([

--- a/packages/materialnote/package.js
+++ b/packages/materialnote/package.js
@@ -1,0 +1,40 @@
+Package.describe({
+    name: 'orionjs:materialnote',
+    version: '1.2.1',
+    // Brief, one-line summary of the package.
+    summary: 'MaterialNote for orionjs',
+    // URL to the Git repository containing the source code for this package.
+    git: '',
+    // By default, Meteor will default to using README.md for documentation.
+    // To avoid submitting documentation, set this field to null.
+    documentation: 'README.md'
+});
+
+Package.onUse(function (api) {
+    api.versionsFrom('1.2.1');
+    api.use([
+        'orionjs:base@1.7.0',
+        'orionjs:attributes@1.7.0',
+        'orionjs:filesystem@1.7.0',
+        'cerealkiller:materialnote@1.2.1',
+        'less@2.5.0_2',
+
+        'jquery'
+    ]);
+
+    api.imply([
+        'cerealkiller:materialnote',
+    ]);
+
+    api.addFiles([
+        'attribute.js',
+    ]);
+
+    api.addFiles([
+        'cktooltip.js',
+        'materialnote.html',
+        'materialnote.js',
+        'materialnote.less',
+    ], 'client');
+});
+


### PR DESCRIPTION
Submission for MaterialNote for Orionjs in regards to #380 

As i'm a huge fan of Materialize, and i needed a good text editor on the cheap, I whipped up a quick clone of Orionjs' SummerNote package, but leveraging MaterialNote from https://github.com/Cerealkillerway/materialNote.

It supports attribute usage.  

I did notice a few bugs with it, such as when trying to change fonts, but i'm not sure if that's a problem on MaterialNotes behaviour or something meteor.session related.

Feel free to merge, kill, or contribute.

@nicolaslopezj let me know if this helps you out.