### PR TITLE
Defer the route change on success

### DIFF
--- a/packages/materialize/views/accounts/profile.js
+++ b/packages/materialize/views/accounts/profile.js
@@ -1,5 +1,8 @@
 AutoForm.addHooks('updateProfileForm', {
   onSuccess: function() {
-    RouterLayer.go('myAccount.index');
+    let collection = this.collection;
+    Meteor.defer(function() {
+      RouterLayer.go(collection.indexPath());
+    });
   }
 });

--- a/packages/materialize/views/collections/create.js
+++ b/packages/materialize/views/collections/create.js
@@ -7,6 +7,9 @@ Template.orionMaterializeCollectionsCreate.events({
 
 AutoForm.addHooks('orionMaterializeCollectionsCreateForm', {
   onSuccess: function() {
-    RouterLayer.go(this.collection.indexPath());
+    let collection = this.collection;
+    Meteor.defer(function() {
+      RouterLayer.go(collection.indexPath());
+    });
   }
 });

--- a/packages/materialize/views/collections/update.js
+++ b/packages/materialize/views/collections/update.js
@@ -6,6 +6,9 @@ Template.orionMaterializeCollectionsUpdate.events({
 
 AutoForm.addHooks('orionMaterializeCollectionsUpdateForm', {
   onSuccess: function() {
-    RouterLayer.go(this.collection.indexPath());
+    let collection = this.collection;
+    Meteor.defer(function() {
+      RouterLayer.go(collection.indexPath());
+    });
   }
 });


### PR DESCRIPTION
Allows AutoForm hooks to proceed.

Resolves #411 according to suggestion A.